### PR TITLE
New rock for cephes

### DIFF
--- a/cephes-0-0.rockspec
+++ b/cephes-0-0.rockspec
@@ -1,0 +1,24 @@
+package = 'cephes'
+version = '0-0'
+
+source = {
+   url = 'git://github.com/jucor/torch-cephes.git',
+   branch = 'master'
+}
+
+description = {
+  summary = "Cephes mathematical functions library, wrapped for Torch",
+  homepage = "http://www.netlib.org/cephes/"
+}
+
+dependencies = { 'torch >= 7.0'}
+build = {
+   type = "command",
+   build_command = [[
+cmake -E make_directory build;
+cd build;
+cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH="$(LUA_BINDIR)/.." -DCMAKE_INSTALL_PREFIX="$(PREFIX)"; 
+$(MAKE)
+   ]],
+   install_command = "cd build && $(MAKE) install"
+}

--- a/index.html
+++ b/index.html
@@ -57,6 +57,15 @@ Lua modules available from this location for use with <a href="http://www.luaroc
 1.0-0:&nbsp;<a href="camera-1.0-0.rockspec">rockspec</a><br/></td></tr>
 <tr><td colspan="2" class="spacer"></td></tr>
 <td class="package">
+<p><a name="cephes"></a><b>cephes</b> - Cephes mathematical functions library, wrapped for Torch<br/>
+</p><blockquote><p><br/>
+
+<font size="-1"><a href="git://github.com/jucor/torch-cephes.git">latest sources</a> | <a href="http://www.netlib.org/cephes/" target="_blank">project homepage</a> | License: N/A</font></p>
+</blockquote></a></td>
+<td class="version">
+0-0:&nbsp;<a href="cephes-0-0.rockspec">rockspec</a><br/></td></tr>
+<tr><td colspan="2" class="spacer"></td></tr>
+<td class="package">
 <p><a name="csv"></a><b>csv</b> - A CSV library, for Torch<br/>
 </p><blockquote><p>A CSV read/write library for Torch. <br/>
 

--- a/manifest
+++ b/manifest
@@ -8,6 +8,13 @@ repository = {
          }
       }
    },
+   cephes = {
+      ['0-0'] = {
+         {
+            arch = "rockspec"
+         }
+      }
+   },
    csv = {
       ['1.0-0'] = {
          {


### PR DESCRIPTION
As discussed with @koraykv, here's the rock for the wrappers of the cephes
math library, which provides a slew of math functions. Scipy also uses it.
Once it's merged, I can make an announcement on the torch mailing list.
