### PR TITLE
Add rockspec for torch-hdf5 & update manifest.

### DIFF
--- a/hdf5-0-0.rockspec
+++ b/hdf5-0-0.rockspec
@@ -1,0 +1,28 @@
+package = 'hdf5'
+version = '0-0'
+
+source = {
+   url = 'git://github.com/d11/torch-hdf5.git',
+   branch = 'master'
+}
+
+description = {
+  summary = "Interface to HDF5 library",
+  homepage = "http://d11.github.io/torch-hdf5",
+  detailed = "Read and write Torch tensor data to and from Hierarchical Data Format files.",
+  license = "BSD",
+  maintainer = "Dan Horgan <danhgn+github@gmail.com>"
+}
+
+dependencies = { 'torch >= 7.0', 'torchffi', 'lualogging', 'penlight' }
+external_dependencies = { hdf5 = { library = 'hdf5' } }
+build = {
+   type = "command",
+   build_command = [[
+cmake -E make_directory build;
+cd build;
+cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH="$(LUA_BINDIR)/.." -DCMAKE_INSTALL_PREFIX="$(PREFIX)"; 
+$(MAKE)
+   ]],
+   install_command = "cd build && $(MAKE) install"
+}

--- a/index.html
+++ b/index.html
@@ -229,6 +229,15 @@ scm-1:&nbsp;<a href="gnuplot-scm-1.rockspec">rockspec</a><br/></td></tr>
 1.scm-0:&nbsp;<a href="graphicsmagick-1.scm-0.rockspec">rockspec</a><br/></td></tr>
 <tr><td colspan="2" class="spacer"></td></tr>
 <td class="package">
+<p><a name="hdf5"></a><b>hdf5</b> - Interface to HDF5 library<br/>
+</p><blockquote><p>Read and write Torch tensor data to and from Hierarchical Data Format files.<br/>
+<p><b>External dependencies:</b> hdf5</p>
+<font size="-1"><a href="git://github.com/d11/torch-hdf5.git">latest sources</a> | <a href="http://d11.github.io/torch-hdf5" target="_blank">project homepage</a> | License: BSD</font></p>
+</blockquote></a></td>
+<td class="version">
+0-0:&nbsp;<a href="hdf5-0-0.rockspec">rockspec</a><br/></td></tr>
+<tr><td colspan="2" class="spacer"></td></tr>
+<td class="package">
 <p><a name="image"></a><b>image</b> - An image library for Torch<br/>
 </p><blockquote><p>This package provides routines to load/save and manipulate images using Torch's Tensor data structure. <br/>
 

--- a/manifest
+++ b/manifest
@@ -167,6 +167,13 @@ repository = {
          }
       }
    },
+   hdf5 = {
+      ['0-0'] = {
+         {
+            arch = "rockspec"
+         }
+      }
+   },
    image = {
       ['1.0-0'] = {
          {

--- a/manifest-5.1
+++ b/manifest-5.1
@@ -167,6 +167,13 @@ repository = {
          }
       }
    },
+   hdf5 = {
+      ['0-0'] = {
+         {
+            arch = "rockspec"
+         }
+      }
+   },
    image = {
       ['1.0-0'] = {
          {

--- a/manifest-5.2
+++ b/manifest-5.2
@@ -167,6 +167,13 @@ repository = {
          }
       }
    },
+   hdf5 = {
+      ['0-0'] = {
+         {
+            arch = "rockspec"
+         }
+      }
+   },
    image = {
       ['1.0-0'] = {
          {


### PR DESCRIPTION
This package allows you to read and write Torch data from and to HDF5
files. The format is fast, flexible, and supported by a wide range of
other software - including MATLAB, Python, and R.
