### PR TITLE
Change hdf5 to use logroll instead of lualogging

### DIFF
--- a/hdf5-0-0.rockspec
+++ b/hdf5-0-0.rockspec
@@ -14,7 +14,7 @@ description = {
   maintainer = "Dan Horgan <danhgn+github@gmail.com>"
 }
 
-dependencies = { 'torch >= 7.0', 'torchffi', 'lualogging', 'penlight' }
+dependencies = { 'torch >= 7.0', 'torchffi', 'logroll', 'penlight' }
 external_dependencies = { hdf5 = { library = 'hdf5' } }
 build = {
    type = "command",


### PR DESCRIPTION
My hdf5 wrapper now uses a different logging library, so this pull request updates the dependency in its rockspec.
