### PR TITLE
Remove explicit HDF5 dependency from hdf5 rockspec.

### DIFF
--- a/hdf5-0-0.rockspec
+++ b/hdf5-0-0.rockspec
@@ -15,7 +15,6 @@ description = {
 }
 
 dependencies = { 'torch >= 7.0', 'logroll', 'penlight' }
-external_dependencies = { hdf5 = { library = 'hdf5' } }
 build = {
    type = "command",
    build_command = [[

--- a/index.html
+++ b/index.html
@@ -267,7 +267,7 @@ scm-1:&nbsp;<a href="graph-scm-1.rockspec">rockspec</a><br/></td></tr>
 <td class="package">
 <p><a name="hdf5"></a><b>hdf5</b> - Interface to HDF5 library<br/>
 </p><blockquote><p>Read and write Torch tensor data to and from Hierarchical Data Format files.<br/>
-<p><b>External dependencies:</b> hdf5</p>
+
 <font size="-1"><a href="git://github.com/d11/torch-hdf5.git">latest sources</a> | <a href="http://d11.github.io/torch-hdf5" target="_blank">project homepage</a> | License: BSD</font></p>
 </blockquote></a></td>
 <td class="version">


### PR DESCRIPTION
This causes problems unnecessarily on some platforms (e.g. current Ubuntu), where luarocks is unable
to find HDF5 even though it's installed and CMake can find it just fine. We can
avoid the trouble by removing the dependency from the rockspec and relying on
CMake to tell the user if HDF5 is missing.
