### PR TITLE
Change source url to not require SSH

### DIFF
--- a/plplot-0-0.rockspec
+++ b/plplot-0-0.rockspec
@@ -2,7 +2,7 @@ package = "plplot"
 version = "0-0"
 
 source = {
-  url = 'git+file://git@github.com:deepmind/plplot-ffi.git',
+  url = 'git://github.com/deepmind/plplot-ffi.git',
   branch = 'master'
 }
 


### PR DESCRIPTION
Current URL will give public key errors if you try to install it with luarocks (and are not a member of deepmind). I think this new url will work for anyone.