### PR TITLE
README: update rocks page location

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ If you want to contribute and share some code, just create a rock for it, and
 make a pull request to this repo. When commiting your rocks, you should also
 run the script [make-manifest.lua](https://github.com/torch/rocks/blob/master/make-manifest.lua),
 provided in this repo, to update the manifest and the html summary. The summary
-is viewable at all times [here](http://torch.github.io/rocks).
+is viewable at all times [here](http://htmlpreview.github.io/?https://github.com/torch/rocks/blob/master/index.html).
 
 Make sure your [luajit-rocks](https://github.com/torch/luajit-rocks) is up to date 
 as you will require luarocks `version > 2.2` to make the manifest.


### PR DESCRIPTION
With the new site the former link gives a 404:

```
curl -L --head http://torch.github.io/rocks
```

I took this one from the former [redirection](https://github.com/torch/torch.github.io/blob/6f8e47f/rocks.html#L1).