### PR TITLE
Add missing dependencies to fn-0-0 rockspec.

### DIFF
--- a/fn-0-0.rockspec
+++ b/fn-0-0.rockspec
@@ -11,7 +11,7 @@ description = {
     homepage = "https://github.com/akfidjeland/lua-fn.git"
 }
 
-dependencies = { 'torch >= 7.0'}
+dependencies = { 'torch >= 7.0', 'util', 'totem'}
 build = {
     type = 'builtin',
     modules = {


### PR DESCRIPTION
util and totem are required but not specified.

This is reflected here: https://github.com/akfidjeland/lua-fn/blob/master/fn-0-0.rockspec but this version is missing those changes.