### PR TITLE
Update torchx-scm-1.rockspec

### DIFF
--- a/torchx-scm-1.rockspec
+++ b/torchx-scm-1.rockspec
@@ -25,7 +25,19 @@ build = {
    build_command = [[
 git submodule init
 git submodule update
-cmake -E make_directory build && cd build && cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH="$(LUA_BINDIR)/.." -DCMAKE_INSTALL_PREFIX="$(PREFIX)" && $(MAKE)
+cmake -E make_directory build;
+cd build;
+cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH="$(LUA_BINDIR)/.." -DCMAKE_INSTALL_PREFIX="$(PREFIX)"; 
+$(MAKE)
    ]],
+
+  platforms = {
+      windows = {
+      build_command  = [[
+cmake -E make_directory build && cd build && cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH="$(LUA_BINDIR)/.." -DCMAKE_INSTALL_PREFIX="$(PREFIX)" && $(MAKE)
+]]
+      }
+   },
+   
    install_command = "cd build && $(MAKE) install"
 }


### PR DESCRIPTION
 'git submodule' commands removed from the Windows build_command;
(they resulted in 'no .git' error)
separate build_command for Windows platform