### PR TITLE
Update dp rockspec, which now requires 'fs'.

### DIFF
--- a/dp-scm-1.rockspec
+++ b/dp-scm-1.rockspec
@@ -22,6 +22,7 @@ dependencies = {
    "moses >= 1.3.1",
    "nnx >= 0.1",
    "dpnn >= 1.0",
+   "fs >= 0.3",
    "xlua >= 1.0",
    "image >= 1.0",
    "luafilesystem >= 1.6.2",


### PR DESCRIPTION
The rockspec for dp is not current. This commit updates the rockspec to https://github.com/nicholas-leonard/dp/blob/master/rocks/dp-scm-1.rockspec