### PR TITLE
Add classic rockspec

### DIFF
--- a/classic-scm-1.rockspec
+++ b/classic-scm-1.rockspec
@@ -1,0 +1,29 @@
+package = "classic"
+version = "scm-1"
+description = {
+    summary = "Class system",
+    detailed = [[ Classic is a class system for Lua. ]]
+}
+
+source = {
+    url = "git://github.com/deepmind/classic.git",
+    branch = 'master'
+}
+
+dependencies = { "torch >= 7.0", "totem" }
+
+build = {
+    type = 'builtin',
+    modules = {
+        classic = "classic/init.lua",
+        ["classic.Class"] = "classic/Class.lua",
+        ["classic.Module"] = "classic/Module.lua",
+        ["classic.torch"] = "classic/torch/init.lua",
+
+        ["classic.tests.class.common"] = "classic/tests/class/common.lua",
+        ["classic.tests.class.definitions"] = "classic/tests/class/definitions.lua",
+        ["classic.tests.class.utils"] = "classic/tests/class/utils.lua",
+
+        ["classic.tests.module.test"] = "classic/tests/module/test.lua",
+    },
+}

--- a/index.html
+++ b/index.html
@@ -121,6 +121,15 @@ scm-1:&nbsp;<a href="ccn2-scm-1.rockspec">rockspec</a><br/></td></tr>
 scm-1:&nbsp;<a href="class-scm-1.rockspec">rockspec</a><br/>0.5.0-0:&nbsp;<a href="class-0.5.0-0.rockspec">rockspec</a><br/></td></tr>
 <tr><td colspan="2" class="spacer"></td></tr>
 <td class="package">
+<p><a name="classic"></a><a href="#classic" class="pkg"><b>classic</b></a> - Class system<br/>
+</p><blockquote><p> Classic is a class system for Lua. <br/>
+
+<font size="-1"><a href="git://github.com/deepmind/classic.git">latest sources</a>  | License: N/A</font></p>
+</blockquote></a></td>
+<td class="version">
+scm-1:&nbsp;<a href="classic-scm-1.rockspec">rockspec</a><br/></td></tr>
+<tr><td colspan="2" class="spacer"></td></tr>
+<td class="package">
 <p><a name="clnn"></a><a href="#clnn" class="pkg"><b>clnn</b></a> - Torch OpenCL Neural Network Implementation<br/>
 </p><blockquote><p> <br/>
 
@@ -919,7 +928,7 @@ scm-1:&nbsp;<a href="torch-scm-1.rockspec">rockspec</a><br/>7.scm-0:&nbsp;<a hre
 <font size="-1"><a href="git://github.com/iamalbert/torch-word-emb">latest sources</a> | <a href="https://github.com/iamalbert/torch-word-emb" target="_blank">project homepage</a> | License: BSD</font></p>
 </blockquote></a></td>
 <td class="version">
-1.2-0:&nbsp;<a href="torch-word-emb-1.2-0.rockspec">rockspec</a><br/>1.1-6:&nbsp;<a href="torch-word-emb-1.1-6.rockspec">rockspec</a><br/></td></tr>
+1.2-0:&nbsp;<a href="torch-word-emb-1.2-0.rockspec">rockspec</a><br/></td></tr>
 <tr><td colspan="2" class="spacer"></td></tr>
 <td class="package">
 <p><a name="torchffi"></a><a href="#torchffi" class="pkg"><b>torchffi</b></a> - Enables FFI bindings for Torch<br/>

--- a/manifest
+++ b/manifest
@@ -98,6 +98,13 @@ repository = {
          }
       }
    },
+   classic = {
+      ["scm-1"] = {
+         {
+            arch = "rockspec"
+         }
+      }
+   },
    clnn = {
       ["scm-1"] = {
          {
@@ -760,11 +767,6 @@ repository = {
       }
    },
    ["torch-word-emb"] = {
-      ["1.1-6"] = {
-         {
-            arch = "rockspec"
-         }
-      },
       ["1.2-0"] = {
          {
             arch = "rockspec"

--- a/manifest-5.1
+++ b/manifest-5.1
@@ -98,6 +98,13 @@ repository = {
          }
       }
    },
+   classic = {
+      ["scm-1"] = {
+         {
+            arch = "rockspec"
+         }
+      }
+   },
    clnn = {
       ["scm-1"] = {
          {
@@ -760,11 +767,6 @@ repository = {
       }
    },
    ["torch-word-emb"] = {
-      ["1.1-6"] = {
-         {
-            arch = "rockspec"
-         }
-      },
       ["1.2-0"] = {
          {
             arch = "rockspec"

--- a/manifest-5.2
+++ b/manifest-5.2
@@ -98,6 +98,13 @@ repository = {
          }
       }
    },
+   classic = {
+      ["scm-1"] = {
+         {
+            arch = "rockspec"
+         }
+      }
+   },
    clnn = {
       ["scm-1"] = {
          {
@@ -760,11 +767,6 @@ repository = {
       }
    },
    ["torch-word-emb"] = {
-      ["1.1-6"] = {
-         {
-            arch = "rockspec"
-         }
-      },
       ["1.2-0"] = {
          {
             arch = "rockspec"

--- a/manifest-5.3
+++ b/manifest-5.3
@@ -98,6 +98,13 @@ repository = {
          }
       }
    },
+   classic = {
+      ["scm-1"] = {
+         {
+            arch = "rockspec"
+         }
+      }
+   },
    clnn = {
       ["scm-1"] = {
          {
@@ -760,11 +767,6 @@ repository = {
       }
    },
    ["torch-word-emb"] = {
-      ["1.1-6"] = {
-         {
-            arch = "rockspec"
-         }
-      },
       ["1.2-0"] = {
          {
             arch = "rockspec"


### PR DESCRIPTION
This would be useful to have available as a dependency for other luarocks packages. Would like to submit `rlenvs` eventually and think other packages, like @bshillingford's `nnquery`, would also benefit.

This PR has the side-effect of removing of removing an old version of `torch-word-emb`. Let me know if you want these as separate commits.