### PR TITLE
add rainbowlog rockspec

### DIFF
--- a/rainbowlog-1.0-0.rockspec
+++ b/rainbowlog-1.0-0.rockspec
@@ -1,0 +1,23 @@
+package = "rainbowlog"
+version = "1.0-0"
+
+source = {
+   url = "git://github.com/cdluminate/torch-rainbowlog",
+   tag = "master",
+}
+
+description = {
+   summary = "Colorful screen logging helper for Lua.",
+   detailed = [[ Colorful screen logging helper for Lua. ]],
+   homepage = "https://github.com/cdluminate/torch-rainbowlog",
+   license = "MIT"
+}
+
+dependencies = { }
+
+build = {
+   type = "builtin",
+   modules = {
+      ['rainbowlog.init'] = 'init.lua',
+   }
+}


### PR DESCRIPTION
This is a screen logging helper module in GLOG style. I use it nearly everywhere in my Torch code.
It is somewhat hacky but someone may like it.

https://github.com/cdluminate/torch-rainbowlog

But I encountered a problem when running `make-manifest.lua`:
```
$ luajit make-manifest.lua 
Already up-to-date.
Making manifest for .
Generating index.html for .
luajit: make-manifest.lua:14: attempt to index a nil value
stack traceback:
	make-manifest.lua:14: in main chunk
	[C]: at 0x004048b0
```